### PR TITLE
Expose cached encoders

### DIFF
--- a/Sources/Tiktoken/Tiktoken.swift
+++ b/Sources/Tiktoken/Tiktoken.swift
@@ -1,44 +1,49 @@
 import Foundation
 
 public actor Tiktoken {
-    
-    public static let shared = Tiktoken()
-    
-    private init() {}
-    
-	 var cachedEncoders: [String: Encoding] = [:]
-	
-    public func getEncoding(_ name: String) async throws -> Encoding? {
-		 if let current = cachedEncoders[name] { return current }
-		 if let encodingName = Model.MODEL_TO_ENCODING[name], let existing = cachedEncoders.values.first(where: { $0.name == encodingName }) { return existing }
 
-        guard let vocab = Model.getEncoding(name) else { 
-			  print("Failed to find vocabulary for \(name)")
-			  return nil
-		  }
+    public static let shared = Tiktoken()
+
+    private init() {}
+
+    public var cachedEncoders: [String: Encoding] = [:]
+
+    public func getEncoding(_ name: String) async throws -> Encoding? {
+        if let current = cachedEncoders[name] { return current }
+        if let encodingName = Model.MODEL_TO_ENCODING[name],
+            let existing = cachedEncoders.values.first(where: { $0.name == encodingName })
+        {
+            return existing
+        }
+
+        guard let vocab = Model.getEncoding(name) else {
+            print("Failed to find vocabulary for \(name)")
+            return nil
+        }
         let encoder = await loadRanks(vocab)
         let regex = try NSRegularExpression(pattern: vocab.pattern)
-        let encoding = Encoding(name: name, regex: regex, mergeableRanks: encoder, specialTokens: vocab.specialTokens)
-		 
-		  cachedEncoders[name] = encoding
+        let encoding = Encoding(
+            name: name, regex: regex, mergeableRanks: encoder, specialTokens: vocab.specialTokens)
+
+        cachedEncoders[name] = encoding
         return encoding
     }
-    
-//    public func getEncoding(for vocab: Vocab) -> Encoding? {
-//        return nil
-//    }
-//    
-//    public func register() {
-//        // TODO: Register model and Encoding
-//    }
-//    
-//    public func clear() {
-//        // TODO: Clear all cached encoding
-//    }
+
+    //    public func getEncoding(for vocab: Vocab) -> Encoding? {
+    //        return nil
+    //    }
+    //
+    //    public func register() {
+    //        // TODO: Register model and Encoding
+    //    }
+    //
+    //    public func clear() {
+    //        // TODO: Clear all cached encoding
+    //    }
 }
 
-private extension Tiktoken {
-    func loadRanks(_ vocab: Vocab) async -> [[UInt8]: Int] {
+extension Tiktoken {
+    fileprivate func loadRanks(_ vocab: Vocab) async -> [[UInt8]: Int] {
         if ["gpt2", "gpt3"].contains(vocab.name) {
             return await Load.dataGymToMergeableBpeRanks(vocabBpeFile: vocab.url)
         } else {


### PR DESCRIPTION
We prefetch these on app open so that we don't have to do the async call when we need the token encoding. Exposing this var allows us to get the encoding from a synchronous context