### PR TITLE
Add support for fine-tuned models

### DIFF
--- a/Sources/Tiktoken/Model.swift
+++ b/Sources/Tiktoken/Model.swift
@@ -18,6 +18,10 @@ enum Model {
 }
 
 extension Model {
+    static let IGNORED_PREFIXES: [String] = [
+        "ft:"  // Fine-tuned versions of standard models
+    ]
+
     static let MODEL_PREFIX_TO_ENCODING: [String: String] = [
         // chat
         "gpt-4o-": "o200k_base",

--- a/Sources/Tiktoken/Tiktoken.swift
+++ b/Sources/Tiktoken/Tiktoken.swift
@@ -11,6 +11,12 @@ public actor Tiktoken {
     }
 
     public func getEncoding(_ name: String) async throws -> Encoding? {
+        var name = name
+
+        for ignoredPrefix in Model.IGNORED_PREFIXES where name.hasPrefix(ignoredPrefix) {
+            name = String(name.dropFirst(ignoredPrefix.count))
+        }
+
         if let current = Self.cache.object(forKey: name as NSString) {
             return current
         }


### PR DESCRIPTION
Ignore "ft:" model name prefix in Tiktoken's model selection logic.