### PR TITLE
[AIQ-1971] model binding updates

### DIFF
--- a/Sources/Tiktoken/Model.swift
+++ b/Sources/Tiktoken/Model.swift
@@ -22,56 +22,42 @@ extension Model {
         "ft:"  // Fine-tuned versions of standard models
     ]
 
+    // NOTE: the following bindings are copied from the current python tiktoken
+    // repo which seems to be the one maintained. All bindings relating to
+    // deprecated models have been removed for clarity sake.
     static let MODEL_PREFIX_TO_ENCODING: [String: String] = [
+        "o1-": "o200k_base",
+        "o3-": "o200k_base",
         // chat
-        "gpt-4o-": "o200k_base",
-        "gpt-4-": "cl100k_base",  // e.g., gpt-4-0314, etc., plus gpt-4-32k
-        "gpt-3.5-turbo-": "cl100k_base",  // e.g, gpt-3.5-turbo-0301, -0401, etc.
+        "chatgpt-4o-": "o200k_base",
+        "gpt-4o-": "o200k_base",            // e.g., gpt-4o-2024-05-13
+        "gpt-4-": "cl100k_base",            // e.g., gpt-4-0314, etc., plus gpt-4-32k
+        "gpt-3.5-turbo-": "cl100k_base",    // e.g, gpt-3.5-turbo-0301, -0401, etc.
+        "gpt-35-turbo-": "cl100k_base",     // Azure deployment name
+        
+        // custom settings (e.g not ported from the python tiktoken code)
+        // 4.1: nothing is official but it's likely to use the same merge
+        // file as 40, e.g o200k_base.
+        "gpt-4.1-": "o200k_base",
     ]
     
     static let MODEL_TO_ENCODING: [String: String] = [
+        // reasoning
+        "o1": "o200k_base",
+        "o3": "o200k_base",
         // chat
         "gpt-4o": "o200k_base",
-        "gpt-4o-mini": "o200k_base",
         "gpt-4": "cl100k_base",
         "gpt-3.5-turbo": "cl100k_base",
-        // text
-        "text-davinci-003": "p50k_base",
-        "text-davinci-002": "p50k_base",
-        "text-davinci-001": "r50k_base",
-        "text-curie-001": "r50k_base",
-        "text-babbage-001": "r50k_base",
-        "text-ada-001": "r50k_base",
-        "davinci": "r50k_base",
-        "curie": "r50k_base",
-        "babbage": "r50k_base",
-        "ada": "r50k_base",
-        // code
-        "code-davinci-002": "p50k_base",
-        "code-davinci-001": "p50k_base",
-        "code-cushman-002": "p50k_base",
-        "code-cushman-001": "p50k_base",
-        "davinci-codex": "p50k_base",
-        "cushman-codex": "p50k_base",
-        // edit
-        "text-davinci-edit-001": "p50k_edit",
-        "code-davinci-edit-001": "p50k_edit",
+        "gpt-3.5": "cl100k_base",       // Common shorthand
+        "gpt-35-turbo": "cl100k_base",  // Azure deployment name
+        // base
+        "davinci-002": "cl100k_base",
+        "babbage-002": "cl100k_base",
         // embeddings
         "text-embedding-ada-002": "cl100k_base",
-        // old embeddings
-        "text-similarity-davinci-001": "r50k_base",
-        "text-similarity-curie-001": "r50k_base",
-        "text-similarity-babbage-001": "r50k_base",
-        "text-similarity-ada-001": "r50k_base",
-        "text-search-davinci-doc-001": "r50k_base",
-        "text-search-curie-doc-001": "r50k_base",
-        "text-search-babbage-doc-001": "r50k_base",
-        "text-search-ada-doc-001": "r50k_base",
-        "code-search-babbage-code-001": "r50k_base",
-        "code-search-ada-code-001": "r50k_base",
-        // open source
-        "gpt2": "gpt2",
-        "gpt3": "gpt3",
+        "text-embedding-3-small": "cl100k_base",
+        "text-embedding-3-large": "cl100k_base",
     ]
     
     static func findPrefix(with name: String) -> Vocab? {

--- a/Sources/Tiktoken/Tiktoken.swift
+++ b/Sources/Tiktoken/Tiktoken.swift
@@ -28,7 +28,6 @@ public actor Tiktoken {
         }
 
         guard let vocab = Model.getEncoding(name) else {
-            print("Failed to find vocabulary for \(name)")
             return nil
         }
         let encoder = await loadRanks(vocab)


### PR DESCRIPTION
It's time to update the model bindings to include the latest stuff like o3. We also didn't have a binding for 4.1 which was causing that "cannot find vocabulary' print during the main response packing (and thus falling back).

Note this PR is mostly to keep things clean but i don't foresee us keeping relying on tiktoken going fwd (slack convo).

# Changes
- took the bindings from the latest python tiktoken codebase and dropped all deprecated entries. Note that 4o-mini has been removed since it's already going to match based on prefix.
- added a prefix for 4.1 using o200k_base: this is not official (and not in the tiktoken opensource code) but that's apparently what 4.1 is using.
- removed that annoying print statement saying it can't find the vocabulary (i'll add a proper logging statement in the packing code.

# Testing
- manual testing with this repo used a local swift package.
- the tests are already kind of broken.
